### PR TITLE
No colons in nickname

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     java
 }
 
-version = "1.0.2"
+version = "1.1.0"
 group = "neyoa.bridge"
 
 minecraft {

--- a/src/main/kotlin/neyoa/bridge/Bridge.kt
+++ b/src/main/kotlin/neyoa/bridge/Bridge.kt
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent
 class Bridge {
     companion object {
         const val MODID = "bridgeformatter"
-        const val VERSION = "1.0.2"
+        const val VERSION = "1.1.0"
         val mc: Minecraft = Minecraft.getMinecraft()
         val config = Config
         var gui: UScreen? = null

--- a/src/main/kotlin/neyoa/bridge/ChatListener.kt
+++ b/src/main/kotlin/neyoa/bridge/ChatListener.kt
@@ -12,7 +12,7 @@ class ChatListener {
         ).containsMatchIn(message)
 
         fun getMessageParts(message: String, chat: String): MatchResult.Destructured {
-            return Regex("^${chat} > (?:\\[\\w+\\+*])? ?${Bridge.config.username.trim()} ?(?:\\[\\w+])?: (?<nickname>.{1,32}): (?<chatMessage>.+)\$").find(
+            return Regex("^${chat} > (?:\\[[A-Z]*\\+*])? ${Bridge.config.username.trim()} (?:\\[[A-Za-z]*])?: (?<nickname>[^:]{1,32}): (?<chatMessage>.+)\$").find(
                 message
             )!!.destructured
         }

--- a/src/main/kotlin/neyoa/bridge/ChatListener.kt
+++ b/src/main/kotlin/neyoa/bridge/ChatListener.kt
@@ -12,7 +12,7 @@ class ChatListener {
         ).containsMatchIn(message)
 
         fun getMessageParts(message: String, chat: String): MatchResult.Destructured {
-            return Regex("^${chat} > (?:\\[[A-Z]*\\+*])? ${Bridge.config.username.trim()} (?:\\[[A-Za-z]*])?: (?<nickname>[^:]{1,32}): (?<chatMessage>.+)\$").find(
+            return Regex("^Guild > (?:\\[\\w+\\+*] )?lesbianeyoa(?: \\[\\w+])?: (?:(?<nickname>.*?): )(?<chatMessage>.+)").find(
                 message
             )!!.destructured
         }


### PR DESCRIPTION
With a chat message like `Guild > [VIP+] lesbianeyoa [Staff]: CatAi: owo: uwu`, the old regex would grab `CatAi: owo` as the discord name, while this regex would just grab `CatAi`. Still not ideal, as it cant tell if the colon is in the discord name or not, but I'm like 98.3% sure that colons in mesages are more common than colons in discord names.